### PR TITLE
Laravel 10 compatibility

### DIFF
--- a/src/Commands/DispatchNow.php
+++ b/src/Commands/DispatchNow.php
@@ -15,6 +15,6 @@ class DispatchNow extends Dispatch
 
     protected function dispatch($job)
     {
-        dispatch_now($job);
+        dispatch_sync($job);
     }
 }


### PR DESCRIPTION
dispatch_now has been deprecated in Laravel 8 and was removed from laravel 10